### PR TITLE
ESP32-S2 starter: non-blocking blink + WiFiManager, OTA, and MQTT

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,30 @@
-# Summary
-Learning to code with CODEX
+# ESP32-S2 Embedded System Starter
 
-## Details
-Planing to start with a BLINK sketch  
-Remove maginc numbers  
-Remove delay (got to multitasking coding)  
-Add WiFi Manager and OTA  
-Add MQTT PubSub  
-Make Boot Button Publish  
+## Features implemented
+- Starts from a **BLINK** baseline using non-blocking timing.
+- Replaces magic numbers with `constexpr` constants.
+- Removes `delay()` and uses cooperative multitasking patterns.
+- Uses **WiFiManager** for Wi-Fi provisioning.
+- Enables **OTA** firmware updates with ArduinoOTA.
+- Adds **MQTT PubSub** connectivity.
+- Publishes a message when the **BOOT button** is pressed.
+
+## Sketch
+- `esp32s2_system.ino`
+
+## Required libraries
+Install these libraries in Arduino IDE (or PlatformIO equivalents):
+- `WiFiManager`
+- `PubSubClient`
+- `ArduinoOTA` (comes with ESP32 Arduino core)
+
+## Configuration to update
+Before flashing, update these constants in the sketch:
+- `MQTT_BROKER`
+- `MQTT_PORT`
+- `MQTT_CLIENT_ID`
+- MQTT topics (`MQTT_TOPIC_STATUS`, `MQTT_TOPIC_BOOT`)
+
+## Notes
+- BOOT button is configured on GPIO `0` with `INPUT_PULLUP`.
+- LED pin uses `LED_BUILTIN`; override if your board uses a different pin.

--- a/esp32s2_system.ino
+++ b/esp32s2_system.ino
@@ -1,0 +1,112 @@
+#include <WiFi.h>
+#include <WiFiManager.h>
+#include <ArduinoOTA.h>
+#include <PubSubClient.h>
+
+// Hardware pins (ESP32-S2)
+constexpr uint8_t LED_PIN = LED_BUILTIN;
+constexpr uint8_t BOOT_BUTTON_PIN = 0;
+
+// Timings (ms)
+constexpr uint32_t BLINK_INTERVAL_MS = 500;
+constexpr uint32_t MQTT_RECONNECT_INTERVAL_MS = 5000;
+constexpr uint32_t BUTTON_DEBOUNCE_MS = 40;
+
+// MQTT configuration
+constexpr char MQTT_BROKER[] = "192.168.1.50";
+constexpr uint16_t MQTT_PORT = 1883;
+constexpr char MQTT_CLIENT_ID[] = "esp32s2-node";
+constexpr char MQTT_TOPIC_STATUS[] = "esp32s2/status";
+constexpr char MQTT_TOPIC_BOOT[] = "esp32s2/boot_button";
+
+WiFiClient wifiClient;
+PubSubClient mqttClient(wifiClient);
+WiFiManager wm;
+
+bool ledState = false;
+bool lastButtonReading = HIGH;
+bool debouncedButtonState = HIGH;
+uint32_t lastBlinkMs = 0;
+uint32_t lastMqttReconnectMs = 0;
+uint32_t lastDebounceMs = 0;
+
+void mqttCallback(char* topic, byte* payload, unsigned int length) {
+  (void)topic;
+  (void)payload;
+  (void)length;
+  // Add subscription handling here when needed.
+}
+
+void setupOTA() {
+  ArduinoOTA.setHostname(MQTT_CLIENT_ID);
+  ArduinoOTA.begin();
+}
+
+void connectMqttIfNeeded(uint32_t nowMs) {
+  if (mqttClient.connected()) {
+    return;
+  }
+
+  if ((nowMs - lastMqttReconnectMs) < MQTT_RECONNECT_INTERVAL_MS) {
+    return;
+  }
+  lastMqttReconnectMs = nowMs;
+
+  if (mqttClient.connect(MQTT_CLIENT_ID)) {
+    mqttClient.publish(MQTT_TOPIC_STATUS, "online", true);
+  }
+}
+
+void handleBlink(uint32_t nowMs) {
+  if ((nowMs - lastBlinkMs) < BLINK_INTERVAL_MS) {
+    return;
+  }
+
+  lastBlinkMs = nowMs;
+  ledState = !ledState;
+  digitalWrite(LED_PIN, ledState ? HIGH : LOW);
+}
+
+void handleBootButton(uint32_t nowMs) {
+  const bool rawReading = digitalRead(BOOT_BUTTON_PIN);
+
+  if (rawReading != lastButtonReading) {
+    lastDebounceMs = nowMs;
+    lastButtonReading = rawReading;
+  }
+
+  if ((nowMs - lastDebounceMs) < BUTTON_DEBOUNCE_MS) {
+    return;
+  }
+
+  if (debouncedButtonState != rawReading) {
+    debouncedButtonState = rawReading;
+    if (debouncedButtonState == LOW && mqttClient.connected()) {
+      mqttClient.publish(MQTT_TOPIC_BOOT, "pressed", false);
+    }
+  }
+}
+
+void setup() {
+  pinMode(LED_PIN, OUTPUT);
+  pinMode(BOOT_BUTTON_PIN, INPUT_PULLUP);
+  digitalWrite(LED_PIN, LOW);
+
+  mqttClient.setServer(MQTT_BROKER, MQTT_PORT);
+  mqttClient.setCallback(mqttCallback);
+
+  // Starts captive portal if credentials are not already saved.
+  wm.autoConnect("ESP32S2-Setup");
+
+  setupOTA();
+}
+
+void loop() {
+  const uint32_t nowMs = millis();
+
+  ArduinoOTA.handle();
+  connectMqttIfNeeded(nowMs);
+  mqttClient.loop();
+  handleBlink(nowMs);
+  handleBootButton(nowMs);
+}


### PR DESCRIPTION
### Motivation
- Provide an ESP32-S2 starter sketch that moves from a blocking BLINK example to a multitasking-friendly baseline. 
- Remove magic numbers and `delay()` usage and add connectivity and remote management features for rapid prototyping. 
- Enable publishing Boot button events over MQTT for integration with home automation or telemetry.

### Description
- Added a new Arduino sketch `esp32s2_system.ino` that centralizes configuration with `constexpr` constants and implements non-blocking timing via `millis()` for blink and task scheduling. 
- Integrated Wi-Fi provisioning using `WiFiManager` with `wm.autoConnect(

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f39448057c8328ba86c8ecbb009fea)