### PR TITLE
Set ESP32 Dev Kit 1 LED pin and configure public ShiftR MQTT settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ESP32-S2 Embedded System Starter
+# ESP32 Dev Kit 1 Embedded System Starter
 
 ## Features implemented
 - Starts from a **BLINK** baseline using non-blocking timing.
@@ -20,11 +20,12 @@ Install these libraries in Arduino IDE (or PlatformIO equivalents):
 
 ## Configuration to update
 Before flashing, update these constants in the sketch:
-- `MQTT_BROKER`
-- `MQTT_PORT`
-- `MQTT_CLIENT_ID`
-- MQTT topics (`MQTT_TOPIC_STATUS`, `MQTT_TOPIC_BOOT`)
+- `MQTT_BROKER` (`public.cloud.shiftr.io`)
+- `MQTT_PORT` (`1883`)
+- `MQTT_USER` / `MQTT_PASSWORD` (`public` / `public`)
+- `MQTT_CLIENT_ID` (`F4650BBB3EDC`)
+- MQTT topics publish/subscribe (`F4650BBB3EDC_ALM`, `F4650BBB3EDC_ACK`)
 
 ## Notes
 - BOOT button is configured on GPIO `0` with `INPUT_PULLUP`.
-- LED pin uses `LED_BUILTIN`; override if your board uses a different pin.
+- LED pin is set to GPIO `2` for ESP32 Dev Kit 1 built-in LED.

--- a/esp32s2_system.ino
+++ b/esp32s2_system.ino
@@ -4,7 +4,8 @@
 #include <PubSubClient.h>
 
 // Hardware pins (ESP32-S2)
-constexpr uint8_t LED_PIN = LED_BUILTIN;
+// ESP32 Dev Kit 1 built-in LED is on GPIO2
+constexpr uint8_t LED_PIN = 2;
 constexpr uint8_t BOOT_BUTTON_PIN = 0;
 
 // Timings (ms)
@@ -13,11 +14,13 @@ constexpr uint32_t MQTT_RECONNECT_INTERVAL_MS = 5000;
 constexpr uint32_t BUTTON_DEBOUNCE_MS = 40;
 
 // MQTT configuration
-constexpr char MQTT_BROKER[] = "192.168.1.50";
+constexpr char MQTT_BROKER[] = "public.cloud.shiftr.io";
 constexpr uint16_t MQTT_PORT = 1883;
-constexpr char MQTT_CLIENT_ID[] = "esp32s2-node";
-constexpr char MQTT_TOPIC_STATUS[] = "esp32s2/status";
-constexpr char MQTT_TOPIC_BOOT[] = "esp32s2/boot_button";
+constexpr char MQTT_USER[] = "public";
+constexpr char MQTT_PASSWORD[] = "public";
+constexpr char MQTT_CLIENT_ID[] = "F4650BBB3EDC";
+constexpr char MQTT_TOPIC_STATUS[] = "F4650BBB3EDC_ALM";
+constexpr char MQTT_TOPIC_BOOT[] = "F4650BBB3EDC_ACK";
 
 WiFiClient wifiClient;
 PubSubClient mqttClient(wifiClient);
@@ -52,8 +55,9 @@ void connectMqttIfNeeded(uint32_t nowMs) {
   }
   lastMqttReconnectMs = nowMs;
 
-  if (mqttClient.connect(MQTT_CLIENT_ID)) {
+  if (mqttClient.connect(MQTT_CLIENT_ID, MQTT_USER, MQTT_PASSWORD)) {
     mqttClient.publish(MQTT_TOPIC_STATUS, "online", true);
+    mqttClient.subscribe(MQTT_TOPIC_BOOT);
   }
 }
 
@@ -82,7 +86,7 @@ void handleBootButton(uint32_t nowMs) {
   if (debouncedButtonState != rawReading) {
     debouncedButtonState = rawReading;
     if (debouncedButtonState == LOW && mqttClient.connected()) {
-      mqttClient.publish(MQTT_TOPIC_BOOT, "pressed", false);
+      mqttClient.publish(MQTT_TOPIC_STATUS, "pressed", false);
     }
   }
 }


### PR DESCRIPTION
### Motivation
- Adapt the sketch to an ESP32 Dev Kit 1 board by using the correct built-in LED pin and update MQTT defaults to a public ShiftR broker for integration testing.
- Provide a readily usable client identity and topics so the device can publish alarms and receive acknowledgements over the public broker.

### Description
- Set `LED_PIN` to `2` for the ESP32 Dev Kit 1 built-in LED and leave BOOT button on GPIO `0` in `esp32s2_system.ino`.
- Change MQTT broker to `public.cloud.shiftr.io`, add `MQTT_USER`/`MQTT_PASSWORD` set to `public`, and set `MQTT_CLIENT_ID` to `F4650BBB3EDC`.
- Configure publish topic to `F4650BBB3EDC_ALM` and subscribe topic to `F4650BBB3EDC_ACK`, switch the connect call to `mqttClient.connect(MQTT_CLIENT_ID, MQTT_USER, MQTT_PASSWORD)` and subscribe to the ACK topic after connecting.
- Update `README.md` to reflect the board, broker, credentials, client ID, and topic defaults.

### Testing
- Ran a repository search with `rg --files && rg -n "GPIO|LED|broker|topic|MQTT|shiftr|ACK|ALM|ESP32|pin" -S .` to locate relevant files and identifiers, which completed successfully.
- Inspected the patch via `git diff -- esp32s2_system.ino README.md` to verify the intended changes were applied, which showed the updated constants and logic.
- Printed the updated files with `nl -ba esp32s2_system.ino` and `nl -ba README.md` to confirm the final contents, and those outputs matched the expected modifications.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f398f3b2a8832883725d784cba7648)