### PR TITLE
Add serial boot banner and Wi-Fi mode/IP reporting

### DIFF
--- a/Project_First_CODEX.ino
+++ b/Project_First_CODEX.ino
@@ -21,6 +21,7 @@ constexpr char MQTT_PASSWORD[] = "public";
 constexpr char MQTT_CLIENT_ID[] = "F4650BBB3EDC";
 constexpr char MQTT_TOPIC_STATUS[] = "F4650BBB3EDC_ALM";
 constexpr char MQTT_TOPIC_BOOT[] = "F4650BBB3EDC_ACK";
+constexpr char PROGRAM_NAME[] = "Project_First_CODEX";
 
 WiFiClient wifiClient;
 PubSubClient mqttClient(wifiClient);
@@ -92,6 +93,13 @@ void handleBootButton(uint32_t nowMs) {
 }
 
 void setup() {
+  Serial.begin(115200);
+  while (!Serial && millis() < 3000) {
+    delay(10);
+  }
+  Serial.println();
+  Serial.printf("[%s] Booting...\n", PROGRAM_NAME);
+
   pinMode(LED_PIN, OUTPUT);
   pinMode(BOOT_BUTTON_PIN, INPUT_PULLUP);
   digitalWrite(LED_PIN, LOW);
@@ -99,8 +107,24 @@ void setup() {
   mqttClient.setServer(MQTT_BROKER, MQTT_PORT);
   mqttClient.setCallback(mqttCallback);
 
+  Serial.println("Wi-Fi startup mode: station with fallback to soft access point (config portal).");
   // Starts captive portal if credentials are not already saved.
   wm.autoConnect("ESP32S2-Setup");
+
+  const wifi_mode_t wifiMode = WiFi.getMode();
+  if (wifiMode == WIFI_AP || wifiMode == WIFI_AP_STA) {
+    Serial.println("Boot mode: soft access point active.");
+    Serial.printf("SoftAP IP: %s\n", WiFi.softAPIP().toString().c_str());
+  } else {
+    Serial.println("Boot mode: station.");
+  }
+
+  if (WiFi.status() == WL_CONNECTED) {
+    Serial.println("Station connected to LAN.");
+    Serial.printf("STA IP: %s\n", WiFi.localIP().toString().c_str());
+  } else {
+    Serial.println("Station not connected to LAN.");
+  }
 
   setupOTA();
 }


### PR DESCRIPTION
### Motivation
- Provide USB/serial feedback during device startup so the program name, boot mode (soft AP vs station), and IP addresses are visible for debugging and setup.

### Description
- Add a `PROGRAM_NAME` constant (`constexpr char PROGRAM_NAME[] = "Project_First_CODEX"`).
- Initialize USB serial in `setup()` with `Serial.begin(115200)`, wait briefly for the port, and print a boot banner with the program name.
- Log Wi-Fi startup behavior and call `wm.autoConnect("ESP32S2-Setup")` as before while printing a startup mode message.
- After `autoConnect()` report whether a soft access point is active (`WiFi.getMode()` and `WiFi.softAPIP()`) and whether the station is connected, printing the STA IP via `WiFi.localIP()` when `WiFi.status() == WL_CONNECTED`.

### Testing
- Ran repository commands `git -C /workspace/Project_First_CODEX status --short`, `git -C /workspace/Project_First_CODEX add Project_First_CODEX.ino`, and `git -C /workspace/Project_First_CODEX commit -m "Add serial boot and Wi-Fi mode/IP reporting"`, all of which succeeded.
- No build or runtime tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3a4eb2a3c8328b471a7f0d6ae9f68)