### PR TITLE
Add WebServer + HTTPUpdateServer and serve root/update pages

### DIFF
--- a/Project_First_CODEX.ino
+++ b/Project_First_CODEX.ino
@@ -2,6 +2,8 @@
 #include <WiFiManager.h>
 #include <ArduinoOTA.h>
 #include <PubSubClient.h>
+#include <WebServer.h>
+#include <HTTPUpdateServer.h>
 
 // Hardware pins (ESP32-S2)
 // ESP32 Dev Kit 1 built-in LED is on GPIO2
@@ -26,6 +28,8 @@ constexpr char PROGRAM_NAME[] = "Project_First_CODEX";
 WiFiClient wifiClient;
 PubSubClient mqttClient(wifiClient);
 WiFiManager wm;
+WebServer webServer(80);
+HTTPUpdateServer httpUpdater;
 
 bool ledState = false;
 bool lastButtonReading = HIGH;
@@ -44,6 +48,20 @@ void mqttCallback(char* topic, byte* payload, unsigned int length) {
 void setupOTA() {
   ArduinoOTA.setHostname(MQTT_CLIENT_ID);
   ArduinoOTA.begin();
+}
+
+void setupWebServer() {
+  webServer.on("/", HTTP_GET, []() {
+    webServer.send(
+      200,
+      "text/html",
+      "<!doctype html><html><head><meta charset='utf-8'><title>Project_First_CODEX</title></head>"
+      "<body><h1>Project_First_CODEX.ino</h1><p>ESP32 sketch with Wi-Fi Manager, OTA, MQTT, and button/LED handling.</p>"
+      "<p>Firmware update page: <a href='/update'>/update</a></p></body></html>");
+  });
+
+  httpUpdater.setup(&webServer, "/update");
+  webServer.begin();
 }
 
 void connectMqttIfNeeded(uint32_t nowMs) {
@@ -127,12 +145,14 @@ void setup() {
   }
 
   setupOTA();
+  setupWebServer();
 }
 
 void loop() {
   const uint32_t nowMs = millis();
 
   ArduinoOTA.handle();
+  webServer.handleClient();
   connectMqttIfNeeded(nowMs);
   mqttClient.loop();
   handleBlink(nowMs);

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 - Removes `delay()` and uses cooperative multitasking patterns.
 - Uses **WiFiManager** for Wi-Fi provisioning.
 - Enables **OTA** firmware updates with ArduinoOTA.
+- Serves a default web page at `/` and browser OTA page at `/update`.
 - Adds **MQTT PubSub** connectivity.
 - Publishes a message when the **BOOT button** is pressed.
 
@@ -29,3 +30,10 @@ Before flashing, update these constants in the sketch:
 ## Notes
 - BOOT button is configured on GPIO `0` with `INPUT_PULLUP`.
 - LED pin is set to GPIO `2` for ESP32 Dev Kit 1 built-in LED.
+
+
+## OTA behavior clarification
+- This project supports both OTA mechanisms:
+  - `ArduinoOTA` for Arduino IDE / `arduino-cli` network upload tools.
+  - HTTP OTA at `http://<device-ip>/update` via `WebServer` + `HTTPUpdateServer`.
+- The default page at `http://<device-ip>/` identifies the running sketch as `Project_First_CODEX.ino` and links to `/update`.


### PR DESCRIPTION
### Motivation
- Provide an HTTP-based OTA fallback and a simple informational web page so firmware can be updated via browser if `ArduinoOTA` tools are not available.
- Make it easier to discover device IP and OTA endpoint from a browser as an alternative to IDE/network upload tools.

### Description
- Added includes for `WebServer` and `HTTPUpdateServer`, created `webServer` and `httpUpdater` instances, and wired them to the main loop.
- Implemented `setupWebServer()` which serves a minimal HTML page at `/` and registers the HTTP OTA endpoint at `/update` via `httpUpdater.setup(&webServer, "/update")`.
- Integrated the web server startup by calling `setupWebServer()` from `setup()` and `webServer.handleClient()` from `loop()` alongside `ArduinoOTA` handling.
- Updated `README.md` to document the new HTTP OTA endpoint and the default root page behavior.

### Testing
- The sketch compiles successfully with the ESP32 Arduino toolchain (`arduino-cli`/Arduino IDE) after the changes.
- No other automated tests were added or executed for this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3a76e9f688328ba90c36387d20579)