### PR TITLE
Add HTTP OTA web server and derive MQTT client ID from MAC; integrate with ArduinoOTA and MQTT

### DIFF
--- a/Project_First_CODEX.ino
+++ b/Project_First_CODEX.ino
@@ -2,6 +2,8 @@
 #include <WiFiManager.h>
 #include <ArduinoOTA.h>
 #include <PubSubClient.h>
+#include <WebServer.h>
+#include <HTTPUpdateServer.h>
 
 // Hardware pins (ESP32-S2)
 // ESP32 Dev Kit 1 built-in LED is on GPIO2
@@ -18,7 +20,6 @@ constexpr char MQTT_BROKER[] = "public.cloud.shiftr.io";
 constexpr uint16_t MQTT_PORT = 1883;
 constexpr char MQTT_USER[] = "public";
 constexpr char MQTT_PASSWORD[] = "public";
-constexpr char MQTT_CLIENT_ID[] = "F4650BBB3EDC";
 constexpr char MQTT_TOPIC_STATUS[] = "F4650BBB3EDC_ALM";
 constexpr char MQTT_TOPIC_BOOT[] = "F4650BBB3EDC_ACK";
 constexpr char PROGRAM_NAME[] = "Project_First_CODEX";
@@ -26,6 +27,9 @@ constexpr char PROGRAM_NAME[] = "Project_First_CODEX";
 WiFiClient wifiClient;
 PubSubClient mqttClient(wifiClient);
 WiFiManager wm;
+WebServer webServer(80);
+HTTPUpdateServer httpUpdater;
+String deviceClientId;
 
 bool ledState = false;
 bool lastButtonReading = HIGH;
@@ -42,8 +46,29 @@ void mqttCallback(char* topic, byte* payload, unsigned int length) {
 }
 
 void setupOTA() {
-  ArduinoOTA.setHostname(MQTT_CLIENT_ID);
+  ArduinoOTA.setHostname(deviceClientId.c_str());
   ArduinoOTA.begin();
+}
+
+String getDeviceClientIdFromMac() {
+  String mac = WiFi.macAddress();
+  mac.replace(":", "");
+  mac.toUpperCase();
+  return mac;
+}
+
+void setupWebServer() {
+  webServer.on("/", HTTP_GET, []() {
+    webServer.send(
+      200,
+      "text/html",
+      "<!doctype html><html><head><meta charset='utf-8'><title>Project_First_CODEX</title></head>"
+      "<body><h1>Project_First_CODEX.ino</h1><p>ESP32 sketch with Wi-Fi Manager, OTA, MQTT, and button/LED handling.</p>"
+      "<p>Firmware update page: <a href='/update'>/update</a></p></body></html>");
+  });
+
+  httpUpdater.setup(&webServer, "/update");
+  webServer.begin();
 }
 
 void connectMqttIfNeeded(uint32_t nowMs) {
@@ -56,7 +81,7 @@ void connectMqttIfNeeded(uint32_t nowMs) {
   }
   lastMqttReconnectMs = nowMs;
 
-  if (mqttClient.connect(MQTT_CLIENT_ID, MQTT_USER, MQTT_PASSWORD)) {
+  if (mqttClient.connect(deviceClientId.c_str(), MQTT_USER, MQTT_PASSWORD)) {
     mqttClient.publish(MQTT_TOPIC_STATUS, "online", true);
     mqttClient.subscribe(MQTT_TOPIC_BOOT);
   }
@@ -111,6 +136,9 @@ void setup() {
   // Starts captive portal if credentials are not already saved.
   wm.autoConnect("ESP32S2-Setup");
 
+  deviceClientId = getDeviceClientIdFromMac();
+  Serial.printf("Device client ID (from MAC): %s\n", deviceClientId.c_str());
+
   const wifi_mode_t wifiMode = WiFi.getMode();
   if (wifiMode == WIFI_AP || wifiMode == WIFI_AP_STA) {
     Serial.println("Boot mode: soft access point active.");
@@ -127,12 +155,14 @@ void setup() {
   }
 
   setupOTA();
+  setupWebServer();
 }
 
 void loop() {
   const uint32_t nowMs = millis();
 
   ArduinoOTA.handle();
+  webServer.handleClient();
   connectMqttIfNeeded(nowMs);
   mqttClient.loop();
   handleBlink(nowMs);

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 - Removes `delay()` and uses cooperative multitasking patterns.
 - Uses **WiFiManager** for Wi-Fi provisioning.
 - Enables **OTA** firmware updates with ArduinoOTA.
+- Serves a default web page at `/` and browser OTA page at `/update`.
 - Adds **MQTT PubSub** connectivity.
 - Publishes a message when the **BOOT button** is pressed.
 
@@ -23,9 +24,17 @@ Before flashing, update these constants in the sketch:
 - `MQTT_BROKER` (`public.cloud.shiftr.io`)
 - `MQTT_PORT` (`1883`)
 - `MQTT_USER` / `MQTT_PASSWORD` (`public` / `public`)
-- `MQTT_CLIENT_ID` (`F4650BBB3EDC`)
 - MQTT topics publish/subscribe (`F4650BBB3EDC_ALM`, `F4650BBB3EDC_ACK`)
+
+MQTT client ID and OTA hostname are derived automatically from the ESP32's MAC address at runtime.
 
 ## Notes
 - BOOT button is configured on GPIO `0` with `INPUT_PULLUP`.
 - LED pin is set to GPIO `2` for ESP32 Dev Kit 1 built-in LED.
+
+
+## OTA behavior clarification
+- This project supports both OTA mechanisms:
+  - `ArduinoOTA` for Arduino IDE / `arduino-cli` network upload tools.
+  - HTTP OTA at `http://<device-ip>/update` via `WebServer` + `HTTPUpdateServer`.
+- The default page at `http://<device-ip>/` identifies the running sketch as `Project_First_CODEX.ino` and links to `/update`.


### PR DESCRIPTION
### Motivation
- Provide an HTTP-based firmware update endpoint and a simple status page, and avoid a hard-coded MQTT client ID by deriving a unique identifier from the device MAC address.

### Description
- Added `WebServer` and `HTTPUpdateServer` instances and a `setupWebServer()` handler that serves a root page and mounts the OTA update endpoint at `/update`.
- Introduced `getDeviceClientIdFromMac()` and a `deviceClientId` string, removed the static `MQTT_CLIENT_ID`, and use `deviceClientId` for both `ArduinoOTA.setHostname()` and `mqttClient.connect()`.
- Hooked `webServer.handleClient()` into the main `loop()` and added `httpUpdater.setup()` so HTTP OTA works alongside `ArduinoOTA` and MQTT.
- Updated `README.md` to document the new web UI, HTTP OTA endpoint, and the change to deriving the MQTT client ID/OTA hostname from the MAC address.

### Testing
- Compiled the sketch for the ESP32 target using `arduino-cli compile` and the build completed successfully.
- No automated unit tests were present or executed for this repository during the rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3a76e9f688328ba90c36387d20579)