### PR TITLE
Customize blink sketch for ESP32-S2 (use GPIO 2)

### DIFF
--- a/Project_First_CODEX.ino
+++ b/Project_First_CODEX.ino
@@ -1,13 +1,14 @@
 // Project_First_CODEX
 // Based on the Arduino built-in "Blink" example.
+// Customized for ESP32-S2 Dev K1: onboard/status LED on GPIO 2.
 
 void setup() {
-  pinMode(LED_BUILTIN, OUTPUT);
+  pinMode(2, OUTPUT);
 }
 
 void loop() {
-  digitalWrite(LED_BUILTIN, HIGH);
+  digitalWrite(2, HIGH);
   delay(1000);
-  digitalWrite(LED_BUILTIN, LOW);
+  digitalWrite(2, LOW);
   delay(1000);
 }


### PR DESCRIPTION
### Motivation
- Implement README step 2 by adapting the example Blink sketch for the ESP32-S2 Dev K1 so the onboard/status LED is driven from GPIO `2`.

### Description
- Modify `Project_First_CODEX.ino` to replace `LED_BUILTIN` with GPIO `2` and add a clarifying comment about the board/LED mapping.

### Testing
- Inspected the updated file with `sed -n '1,220p' Project_First_CODEX.ino` and `nl -ba Project_First_CODEX.ino`, both commands succeeded; no compile/upload was performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5e407022083289a59e8051bd53f3c)