### PR TITLE
Replace magic numbers with named constants in Blink sketch

### DIFF
--- a/Project_First_CODEX.ino
+++ b/Project_First_CODEX.ino
@@ -2,13 +2,17 @@
 // Based on the Arduino built-in "Blink" example.
 // Customized for ESP32-S2 Dev K1: onboard/status LED on GPIO 2.
 
+const uint8_t LED_PIN = 2;
+const unsigned long LED_ON_MS = 1000;
+const unsigned long LED_OFF_MS = 1000;
+
 void setup() {
-  pinMode(2, OUTPUT);
+  pinMode(LED_PIN, OUTPUT);
 }
 
 void loop() {
-  digitalWrite(2, HIGH);
-  delay(1000);
-  digitalWrite(2, LOW);
-  delay(1000);
+  digitalWrite(LED_PIN, HIGH);
+  delay(LED_ON_MS);
+  digitalWrite(LED_PIN, LOW);
+  delay(LED_OFF_MS);
 }


### PR DESCRIPTION
### Motivation
- Implement README step 3 by removing magic numbers from the blink sketch and placing descriptive constants at the top of the file.

### Description
- Added `LED_PIN`, `LED_ON_MS`, and `LED_OFF_MS` constants and replaced inline literals in `setup()` and `loop()` so `pinMode`, `digitalWrite`, and `delay` use the named constants.

### Testing
- Inspected the updated file contents with `nl -ba Project_First_CODEX.ino` and `sed -n '1,220p' Project_First_CODEX.ino`, and the output shows the new constants are present and used.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5e4ed9cc883289632ed045de9ac0c)