### PR TITLE
Remove blocking `delay()` from blink loop (implement README step 4)

### DIFF
--- a/Project_First_CODEX.ino
+++ b/Project_First_CODEX.ino
@@ -6,13 +6,21 @@ const uint8_t LED_PIN = 2;
 const unsigned long LED_ON_MS = 1000;
 const unsigned long LED_OFF_MS = 1000;
 
+bool ledIsOn = false;
+unsigned long lastToggleAtMs = 0;
+
 void setup() {
   pinMode(LED_PIN, OUTPUT);
+  digitalWrite(LED_PIN, LOW);
 }
 
 void loop() {
-  digitalWrite(LED_PIN, HIGH);
-  delay(LED_ON_MS);
-  digitalWrite(LED_PIN, LOW);
-  delay(LED_OFF_MS);
+  const unsigned long nowMs = millis();
+  const unsigned long intervalMs = ledIsOn ? LED_ON_MS : LED_OFF_MS;
+
+  if (nowMs - lastToggleAtMs >= intervalMs) {
+    ledIsOn = !ledIsOn;
+    digitalWrite(LED_PIN, ledIsOn ? HIGH : LOW);
+    lastToggleAtMs = nowMs;
+  }
 }


### PR DESCRIPTION
### Motivation
- The README step 4 requires removing `delay()` to adopt a multitasking-friendly timing approach so the sketch can perform other work in `loop()` without being blocked.

### Description
- Replaced blocking `delay()` calls in `Project_First_CODEX.ino` with a non-blocking scheduler using `millis()`, added `ledIsOn` and `lastToggleAtMs` globals to track state and timing, and initialized the LED to `LOW` in `setup()` for deterministic startup.

### Testing
- Ran `git status --short && git diff -- Project_First_CODEX.ino`, `git add Project_First_CODEX.ino && git commit -m "Implement non-blocking LED blink timing"`, and `nl -ba Project_First_CODEX.ino` as verification steps, and all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5e5aae0f8832893247884a9ae7b51)