### PR TITLE
Implement README step 5 setup progress indicators

### DIFF
--- a/Project_First_CODEX.ino
+++ b/Project_First_CODEX.ino
@@ -3,6 +3,7 @@
 // Customized for ESP32-S2 Dev K1: onboard/status LED on GPIO 2.
 
 const uint8_t LED_PIN = 2;
+const unsigned long SERIAL_BAUD_RATE = 115200;
 const unsigned long LED_ON_MS = 1000;
 const unsigned long LED_OFF_MS = 1000;
 
@@ -11,6 +12,14 @@ unsigned long lastToggleAtMs = 0;
 
 void setup() {
   pinMode(LED_PIN, OUTPUT);
+  digitalWrite(LED_PIN, HIGH);
+
+  Serial.begin(SERIAL_BAUD_RATE);
+  Serial.println("[SETUP] Starting setup...");
+
+  // Placeholder for future setup steps (WiFi, OTA, MQTT, etc.)
+
+  Serial.println("[SETUP] Setup complete.");
   digitalWrite(LED_PIN, LOW);
 }
 


### PR DESCRIPTION
### Motivation
- Implement README step 5 to inform the user of setup progress: start with the LED on, initialize Serial at 115200, print start/end messages on the serial port, and turn the LED off at the end of `setup()`.

### Description
- Added a `SERIAL_BAUD_RATE` constant set to `115200` and used it in `Serial.begin(...)`.
- Turn the LED on at the start of `setup()` via `digitalWrite(LED_PIN, HIGH)` to indicate progress.
- Print `"[SETUP] Starting setup..."` and `"[SETUP] Setup complete."` to the serial port during `setup()`.
- Added a placeholder comment for upcoming initialization steps and ensure the LED is turned off at the end of `setup()` with `digitalWrite(LED_PIN, LOW)`.

### Testing
- Ran repository commands `git status --short`, `git add Project_First_CODEX.ino`, and `git commit` successfully in the environment.
- No Arduino build or hardware upload was executed because a hardware/toolchain environment was not available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5e94404a88328ac039ba976bfc837)